### PR TITLE
DM-55349: Set dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,6 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/"
+    versioning-strategy: "increase-if-necessary"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Set the versioning strategy for dependabot to only increase the top-level bound and not increase the lower bound.